### PR TITLE
feat: update Go to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/itchyny/rassemble-go
 
-go 1.18
+go 1.21


### PR DESCRIPTION
1.22 improves printing of regular expressions.

See https://github.com/golang/go/issues/57950
See https://go-review.googlesource.com/c/go/+/507015